### PR TITLE
Update server binding in app.py to allow external access and add uv.lock file to Dockerfile for dependency synchronization.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update && apt-get install -y \
 
 # Copy project files
 COPY pyproject.toml ./
+COPY uv.lock ./
 
 # Sync dependencies using uv
 RUN uv sync

--- a/app.py
+++ b/app.py
@@ -685,7 +685,7 @@ def main():
     try:
         interface = create_gui()
         interface.launch(
-            server_name="127.0.0.1",
+            server_name="0.0.0.0",
             server_port=7860,
             share=False,
             show_error=True,


### PR DESCRIPTION
Signed-off-by: yukuai0011 <kuyu5570@uni.sydney.edu.au>

## Summary by Sourcery

Allow external clients to reach the app by binding to 0.0.0.0 and ensure Docker builds use a locked dependency file for consistent installs.

Enhancements:
- Bind server to 0.0.0.0 instead of 127.0.0.1 to allow external access

Build:
- Include uv.lock in the Dockerfile before running `uv sync` for dependency synchronization