### PR TITLE
Update license from Apache 2.0 to Mozilla Public License Version 2.0 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,4 +250,4 @@ Feel free to submit issues, feature requests, or pull requests to improve the sy
 
 ## 📄 License
 
-Apache 2.0 License - See LICENSE file for details.
+Mozilla Public License Version 2.0 - See LICENSE file for details.


### PR DESCRIPTION
Signed-off-by: yukuai0011 <kyu@expressluck.com>

## Summary by Sourcery

Documentation:
- Change the README license text from Apache 2.0 to reference the Mozilla Public License 2.0.